### PR TITLE
feat(slack-digest): template header

### DIFF
--- a/gh-issue-slack-digest/action.yml
+++ b/gh-issue-slack-digest/action.yml
@@ -12,8 +12,8 @@ inputs:
   slackWebhookUrl:
     description: Webhook URL used for sending messages to specific channels.
     required: true
-  messageHeader:
-    description: Header to be used in Slack message.
+  messageHeaderPrefix:
+    description: Header prefix to be used in Slack message.
     required: true
   hasLabels:
     description: Labels the issues should have.

--- a/lib/actions/gh-issue-slack-digest.js
+++ b/lib/actions/gh-issue-slack-digest.js
@@ -33,7 +33,7 @@ async function makeDigest() {
     const inputs = {
         token: core.getInput("token"),
         webhookUrl: core.getInput("slackWebhookUrl"),
-        header: core.getInput("messageHeader"),
+        headerPrefix: core.getInput("messageHeaderPrefix"),
         hasLabels: core.getInput("hasLabels"),
         missingLabels: core
             .getInput("missingLabels")
@@ -100,7 +100,7 @@ async function makeDigest() {
             type: "header",
             text: {
                 type: "plain_text",
-                text: inputs.header,
+                text: `${inputs.headerPrefix}: ${owner}/${repo}`,
             },
         },
         ...issueBlocks,

--- a/src/actions/gh-issue-slack-digest.ts
+++ b/src/actions/gh-issue-slack-digest.ts
@@ -9,7 +9,7 @@ async function makeDigest() {
   const inputs = {
     token: core.getInput("token"),
     webhookUrl: core.getInput("slackWebhookUrl"),
-    header: core.getInput("messageHeader"),
+    headerPrefix: core.getInput("messageHeaderPrefix"),
     hasLabels: core.getInput("hasLabels"),
     missingLabels: core
       .getInput("missingLabels")
@@ -81,7 +81,7 @@ async function makeDigest() {
       type: "header",
       text: {
         type: "plain_text",
-        text: inputs.header,
+        text: `${inputs.headerPrefix}: ${owner}/${repo}`,
       },
     },
     ...issueBlocks,

--- a/workflows/gh_issue_slack_digest.yaml
+++ b/workflows/gh_issue_slack_digest.yaml
@@ -15,5 +15,5 @@ jobs:
         uses: konveyor/github-actions/gh-issue-slack-digest@main
         with:
           slackWebhookUrl: ${{ secretes.SLACK_WEBHOOK_URL }}
-          messageHeader: "Issues needing triage for ..."
+          messageHeaderPrefix: "Issues needing triage"
           hasLabels: "needs-triage"


### PR DESCRIPTION
It's really annoying to have to keep track of the ${owner}/${repo}
string that users almost certainly would want in the digest message. So
this just takes the input as a prefix and adds the owner/repo.