### PR TITLE
bug(reconcile-issue): actually sync triaged issues

### DIFF
--- a/lib/actions/reconcile-issue.js
+++ b/lib/actions/reconcile-issue.js
@@ -94,7 +94,7 @@ async function reconcileIssue() {
         return;
     }
     const requiredMissingLabels = inputs.requireMissingLabels.filter((label) => ghIssue.hasLabel(label));
-    if (requiredMissingLabels) {
+    if (requiredMissingLabels.length !== 0) {
         core.warning(`This issue has ${requiredMissingLabels} that indicate this issue is not triaged.`);
         return;
     }

--- a/src/actions/reconcile-issue.ts
+++ b/src/actions/reconcile-issue.ts
@@ -87,7 +87,7 @@ async function reconcileIssue() {
   const requiredMissingLabels = inputs.requireMissingLabels.filter((label) =>
     ghIssue.hasLabel(label)
   );
-  if (requiredMissingLabels) {
+  if (requiredMissingLabels.length !== 0) {
     core.warning(
       `This issue has ${requiredMissingLabels} that indicate this issue is not triaged.`
     );


### PR DESCRIPTION
This commit addresses an issue where GitHub Issues are always seen as
"untriaged" because the `if (requiredMissingLabels)` will always
evaluate to true (even if `[]`). Now, we'll evaluate the length.